### PR TITLE
Update test/common.inc

### DIFF
--- a/tests/common.inc
+++ b/tests/common.inc
@@ -8,6 +8,7 @@ ini_set('blitz.path', $pwd);
 
 ini_set('blitz.remove_spaces_around_context_tags', 0);
 ini_set('blitz.warn_context_duplicates', 1);
+ini_set('blitz.enable_alternative_tags', 1);
 
 // set this handler to simplify error checking for both PHP4 and PHP5
 error_reporting(E_ALL);


### PR DESCRIPTION
Re-defile default blitz.enable_alternative_tags value.
If in buld system already installed blitz and php.ini has changes in default blitz.* values
some test failed:

- tests/clean_globals.phpt
- tests/clean.phpt
- tests/comments_custom.phpt
- tests/incorrect.phpt
- tests/mix4.phpt
- tests/old_style.phpt
- tests/parse_with_iterations.phpt
- tests/phpt_compability.phpt
- tests/set_mixed.phpt
- tests/spaces.phpt
- tests/wrong_iterations.phpt
